### PR TITLE
feat(roles): add per-project role management

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,9 @@
       "Bash(gh api:*)",
       "Bash(jj:*)",
       "Bash(bd create:*)",
-      "Bash(npm test:*)"
+      "Bash(npm test:*)",
+      "Bash(cmux browser:*)",
+      "Bash(npx tsc:*)"
     ]
   },
   "enabledPlugins": {

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,5 @@ LOG_LEVEL="info"
 OPENCLAW_GATEWAY_URL=http://localhost:18790
 OPENCLAW_GATEWAY_TOKEN=change-me
 OPENCLAW_INTERNAL_TOKEN=change-me-internal
+# URL OpenClaw uses to call back into this app (use host.docker.internal when running via docker-compose)
+APP_URL=http://host.docker.internal:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,11 +38,16 @@ services:
     environment:
       - ANTHROPIC_API_KEY=${PI_SDK_API_KEY}
       - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+      - APP_URL=${APP_URL:-http://host.docker.internal:3000}
+      - OPENCLAW_INTERNAL_TOKEN=${OPENCLAW_INTERNAL_TOKEN}
     volumes:
-      - ./openclaw/skills:/home/node/.openclaw/workspace/skills
+      - ./openclaw/skills:/home/node/.openclaw/workspace/skills-src:ro
       - ./openclaw/config/openclaw.json:/home/node/.openclaw/openclaw.json
+      - ./openclaw/entrypoint.sh:/entrypoint.sh
+      - ./.local-efs/repos:/repos:ro
     ports:
       - "18790:18789"
+    entrypoint: ["node", "/entrypoint.sh"]
     command: ["gateway", "--port", "18789"]
 
 volumes:

--- a/openclaw/entrypoint.sh
+++ b/openclaw/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Copy skill templates to a writable location, substitute {{VAR}} placeholders
+// from environment variables, then launch OpenClaw gateway.
+//
+// Skills are mounted read-only at /home/node/.openclaw/workspace/skills-src
+// and copied to /home/node/.openclaw/workspace/skills before substitution.
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const SRC_DIR = "/home/node/.openclaw/workspace/skills-src";
+const DEST_DIR = "/home/node/.openclaw/workspace/skills";
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function substituteTemplates(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      substituteTemplates(full);
+    } else if (entry.name.endsWith(".md")) {
+      const content = fs.readFileSync(full, "utf8");
+      const replaced = content.replace(/\{\{([A-Z0-9_]+)\}\}/g, (match, key) => {
+        return process.env[key] !== undefined ? process.env[key] : match;
+      });
+      fs.writeFileSync(full, replaced);
+    }
+  }
+}
+
+console.log("Copying and resolving skill template variables...");
+try {
+  copyDir(SRC_DIR, DEST_DIR);
+  substituteTemplates(DEST_DIR);
+  console.log("Done.");
+} catch (e) {
+  console.error("Warning: template setup failed:", e.message);
+}
+
+const args = process.argv.slice(2);
+const result = spawnSync("node", ["/app/openclaw.mjs", ...args], {
+  stdio: "inherit",
+  env: process.env,
+});
+process.exit(result.status ?? 1);

--- a/openclaw/skills/create-prd/SKILL.md
+++ b/openclaw/skills/create-prd/SKILL.md
@@ -13,63 +13,76 @@ You are a PRD specialist. Create a clear, comprehensive Product Requirements Doc
 - Start from the user's description and ask clarifying questions if needed
 - **Before generating requirements**, browse the project repository to ground the PRD in the actual codebase:
   1. List the repo root to understand the overall structure
-  2. Read key files: `README.md` (or `README`), `package.json` / `go.mod` / `requirements.txt` / `Gemfile` (whichever exists), any existing PRDs found under `docs/`, and schema files (e.g. `prisma/schema.prisma`, `*.sql`)
+  2. Read key files: `README.md`, `package.json` / `go.mod` / `requirements.txt` (whichever exists), any existing PRDs under `docs/`, and schema files
   3. Note the existing tech stack, architectural patterns, naming conventions, and already-shipped features
   4. Use this context to ensure the new requirements are consistent with the codebase and avoid duplicating existing functionality
 - Focus on the 'What' not the 'How' or 'When'
 - Structure the PRD with standard sections: Summary, Problem Statement, User Analysis, Goals/Non-Goals, Functional Requirements, Non-Functional Requirements, Success Metrics
-- Functional Requirements should be written in standard Gerkin format <https://cucumber.io/docs/gherkin/reference>
+- Functional Requirements should be written in standard Gherkin format <https://cucumber.io/docs/gherkin/reference>
 - Use precise, unambiguous language
 - Include measurable acceptance criteria
 - Output as well-structured Markdown
 
-## Tools
+## Reading the Project Repository
 
-You have access to the following HTTP endpoints to manage PRDs:
+The project repository is mounted at `/repos/{userId}/{projectId}/`. Use bash to read it directly.
 
-### Save PRD
+**You will be given `userId` and `projectId` in the conversation context.**
 
-POST {{APP_URL}}/api/internal/prd/save
-Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
-Content-Type: application/json
+### List directory
 
-Body: { "title": "...", "content": "...", "changeSummary": "...", "userId": "...", "projectId": "..." }
+```bash
+ls /repos/{userId}/{projectId}/
+ls /repos/{userId}/{projectId}/some/subdirectory/
+```
 
-### Read PRD
+### Read a file
 
-GET {{APP_URL}}/api/internal/prd/read?identifier=...&userId=...
-Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
+```bash
+cat /repos/{userId}/{projectId}/path/to/file.md
+```
 
-### List PRDs
+### Search for files by name
 
-GET {{APP_URL}}/api/internal/prd/list?userId=...&projectId=...&search=...
-Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
+```bash
+find /repos/{userId}/{projectId} -name "*.md" -not -path "*/.git/*" | head -30
+```
 
-### Repo Browsing
+### Search file contents
 
-#### Browse directory
+```bash
+grep -r "keyword" /repos/{userId}/{projectId} --include="*.md" -l | head -20
+```
 
-GET {{APP_URL}}/api/internal/repo/browse?projectId=...&userId=...&path=...
-Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
+## Saving the PRD
 
-- `projectId` and `userId` are required.
-- `path` is optional (defaults to the repository root).
-- Returns a single-level listing — not recursive.
-- Response: `{ data: { entries: [{ name, type: "file"|"dir", path }] } }`
-- Returns 404 if the repository has not been cloned yet.
-- Excludes `.git/`, `node_modules/`, `.next/`, `dist/`, and `build/` directories.
+When done, save the final PRD via curl:
 
-#### Read file
+```bash
+curl -s -X POST {{APP_URL}}/api/internal/prd/save \
+  -H "Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "...",
+    "content": "...",
+    "changeSummary": "Initial PRD generation",
+    "userId": "...",
+    "projectId": "..."
+  }'
+```
 
-GET {{APP_URL}}/api/internal/repo/file?projectId=...&userId=...&path=...
-Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
+## Other API Operations (via curl)
 
-- `projectId`, `userId`, and `path` are all required.
-- `path` is the repo-relative path to the file (e.g. `src/app/page.tsx`).
-- Response: `{ data: { content: "...", path: "...", size: N } }`
-- Returns 404 if the file or clone does not exist.
-- Returns 413 if the file exceeds 100 KB — do not attempt to read it.
+### Read an existing PRD
 
-## When done
+```bash
+curl -s "{{APP_URL}}/api/internal/prd/read?identifier=IDENTIFIER&userId=USER_ID" \
+  -H "Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}"
+```
 
-Use the Save PRD endpoint to persist the final PRD content.
+### List PRDs for a project
+
+```bash
+curl -s "{{APP_URL}}/api/internal/prd/list?userId=USER_ID&projectId=PROJECT_ID" \
+  -H "Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}"
+```

--- a/openclaw/skills/refine-prd/SKILL.md
+++ b/openclaw/skills/refine-prd/SKILL.md
@@ -6,20 +6,68 @@ user-invocable: true
 
 # Refine PRD
 
-You are a PRD specialist. Help refine an existing Product Requirements Document.
+Refine and enhance an existing Product Requirements Document based on stakeholder
+feedback, additional research, or identified gaps. Updates PRD while maintaining
+version history and traceability.
 
-## Instructions
-- Analyze the existing PRD for completeness, clarity, and feasibility
-- Suggest specific improvements when asked
-- Preserve the original intent while enhancing quality
-- When the user requests changes, make them precisely
-- Flag any conflicting requirements
+## Workflow
+
+### Phase 1: PRD Review
+
+**1. Current PRD Analysis**
+   Review existing PRD content
+
+**2. Interview users**
+   REQUIRED: Conduct user interview BEFORE making any changes.
+
+Use the AskUserQuestion tool to present questions interactively:
+
+- Ask questions ONE AT A TIME (not all at once)
+- Wait for user answer before asking the next question
+- Do NOT just write questions in your response text
+- The user should see interactive question UI prompts
+
+Ask about:
+
+- Requirements that are unclear or need more detail
+- Missing user scenarios we should address
+- Acceptance criteria completeness and testability
+- Scope definition (in-scope vs out-of-scope)
+- Technical constraints or dependencies not captured
+- Priority order of features/requirements
+- Open questions or decisions needing resolution
+
+**3. Feedback Integration**
+   Incorporate stakeholder feedback
+
+### Phase 2: Enhancement
+
+**1. Content Refinement**
+   Enhance clarity, detail, and completeness
+
+**2. Validation**
+   Ensure all sections meet quality standards
+
+### Phase 3: Output Management
+
+**1. PRD Update**
+   Update PRD with version history
+
+## Expected Output
+
+**Format:** Refined Product Requirements Document (PRD)
+
+**Structure:**
+
+- **Updated PRD**: Enhanced PRD with feedback incorporated
+- **Version History**: Changelog of updates and refinements
 
 ## Tools
 
 You have access to the following HTTP endpoints to manage PRDs:
 
 ### Save PRD
+
 POST {{APP_URL}}/api/internal/prd/save
 Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
 Content-Type: application/json
@@ -27,12 +75,15 @@ Content-Type: application/json
 Body: { "title": "...", "content": "...", "changeSummary": "...", "userId": "...", "projectId": "...", "prdId": "..." }
 
 ### Read PRD
+
 GET {{APP_URL}}/api/internal/prd/read?identifier=...&userId=...
 Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
 
 ### List PRDs
+
 GET {{APP_URL}}/api/internal/prd/list?userId=...&projectId=...&search=...
 Authorization: Bearer {{OPENCLAW_INTERNAL_TOKEN}}
 
 ## When done
+
 Use the Save PRD endpoint to persist the updated PRD content.

--- a/prisma/migrations/20260304000000_add_prd_description/migration.sql
+++ b/prisma/migrations/20260304000000_add_prd_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Prd" ADD COLUMN "description" TEXT;

--- a/prisma/migrations/20260305000000_add_project_role_enum/migration.sql
+++ b/prisma/migrations/20260305000000_add_project_role_enum/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "ProjectRole" AS ENUM ('MEMBER', 'REVIEWER', 'SUBMITTER', 'APPROVER', 'ADMIN');
+
+-- Add new role column with default MEMBER
+ALTER TABLE "ProjectMember" ADD COLUMN "role" "ProjectRole" NOT NULL DEFAULT 'MEMBER';
+
+-- Migrate existing isReviewer data
+UPDATE "ProjectMember" SET "role" = 'REVIEWER' WHERE "isReviewer" = true;
+
+-- Drop old column
+ALTER TABLE "ProjectMember" DROP COLUMN "isReviewer";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,6 +116,7 @@ model ProjectMember {
 model Prd {
   id              String      @id @default(cuid())
   title           String
+  description     String?
   projectId       String
   authorId        String
   status          PrdStatus   @default(DRAFT)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,14 @@ enum Role {
   ADMIN
 }
 
+enum ProjectRole {
+  MEMBER
+  REVIEWER
+  SUBMITTER
+  APPROVER
+  ADMIN
+}
+
 enum ThemePreference {
   LIGHT
   DARK
@@ -105,7 +113,7 @@ model ProjectMember {
   id        String   @id @default(cuid())
   projectId String
   userId    String
-  isReviewer Boolean @default(false)
+  role      ProjectRole @default(MEMBER)
 
   project   Project  @relation(fields: [projectId], references: [id])
   user      User     @relation(fields: [userId], references: [id])

--- a/src/__tests__/e2e-flow.test.ts
+++ b/src/__tests__/e2e-flow.test.ts
@@ -164,7 +164,7 @@ import {
   POST as postComment,
   GET as getComments,
 } from "@/app/api/prds/[id]/comments/route";
-import { PUT as resolveCommentRoute } from "@/app/api/prds/[id]/comments/[commentId]/resolve/route";
+import { PATCH as resolveCommentRoute } from "@/app/api/prds/[id]/comments/[commentId]/resolve/route";
 import { POST as submitPrd } from "@/app/api/prds/[id]/submit/route";
 import { GET as getVersions } from "@/app/api/prds/[id]/versions/route";
 import { GET as searchRoute } from "@/app/api/search/route";
@@ -433,7 +433,7 @@ describe("E2E: Full PRD Lifecycle", () => {
 
     const resolveReq = makeRequest(
       "http://localhost/api/prds/prd_001/comments/comment_001/resolve",
-      "PUT",
+      "PATCH",
     );
     const resolveRes = await resolveCommentRoute(
       resolveReq as any,
@@ -728,7 +728,7 @@ describe("E2E: Comment Threads", () => {
 
     const resolveReq = makeRequest(
       "http://localhost/api/prds/prd_001/comments/comment_001/resolve",
-      "PUT",
+      "PATCH",
     );
     const resolveRes = await resolveCommentRoute(
       resolveReq as any,

--- a/src/__tests__/e2e-flow.test.ts
+++ b/src/__tests__/e2e-flow.test.ts
@@ -341,7 +341,7 @@ describe("E2E: Full PRD Lifecycle", () => {
     const prdReq = makeRequest(
       "http://localhost/api/prds",
       "POST",
-      { projectId: "proj_001", description: "E2E Test PRD" },
+      { projectId: "proj_001", title: "E2E Test PRD", description: "E2E Test PRD description" },
     );
     const prdRes = await createPrd(prdReq as any);
     const prdBody = await prdRes.json();
@@ -614,7 +614,7 @@ describe("E2E: Auth Flow", () => {
     const req = makeRequest(
       "http://localhost/api/prds",
       "POST",
-      { projectId: "proj_001" },
+      { projectId: "proj_001", title: "My PRD" },
     );
     const res = await createPrd(req as any);
     const body = await res.json();

--- a/src/app/api/internal/prd/save/route.ts
+++ b/src/app/api/internal/prd/save/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
       await prisma.$transaction(async (tx) => {
         await tx.prd.update({
           where: { id: prdId },
-          data: { currentVersion: nextVersion },
+          data: { currentVersion: nextVersion, title },
         });
         await tx.prdVersion.create({
           data: {

--- a/src/app/api/prds/[id]/comments/[commentId]/resolve/route.ts
+++ b/src/app/api/prds/[id]/comments/[commentId]/resolve/route.ts
@@ -10,10 +10,10 @@ import { handleApiError } from "@/lib/api/errors";
 import { resolveComment } from "@/services/comment-service";
 
 // ---------------------------------------------------------------------------
-// PUT /api/prds/[id]/comments/[commentId]/resolve
+// PATCH /api/prds/[id]/comments/[commentId]/resolve
 // ---------------------------------------------------------------------------
 
-export async function PUT(
+export async function PATCH(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string; commentId: string }> },
 ) {

--- a/src/app/api/prds/[id]/comments/__tests__/route.test.ts
+++ b/src/app/api/prds/[id]/comments/__tests__/route.test.ts
@@ -2,7 +2,7 @@
  * Comments API route tests.
  *
  * Tests for GET /api/prds/[id]/comments, POST /api/prds/[id]/comments,
- * and PUT /api/prds/[id]/comments/[commentId]/resolve.
+ * and PATCH /api/prds/[id]/comments/[commentId]/resolve.
  */
 
 // ---------------------------------------------------------------------------
@@ -43,7 +43,7 @@ jest.mock("@/services/comment-service", () => ({
 // ---------------------------------------------------------------------------
 
 import { GET, POST } from "../route";
-import { PUT } from "../[commentId]/resolve/route";
+import { PATCH } from "../[commentId]/resolve/route";
 import { UnauthorizedError, ForbiddenError, NotFoundError } from "@/lib/api/errors";
 
 // ---------------------------------------------------------------------------
@@ -255,10 +255,10 @@ describe("POST /api/prds/[id]/comments", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: PUT /api/prds/[id]/comments/[commentId]/resolve
+// Tests: PATCH /api/prds/[id]/comments/[commentId]/resolve
 // ---------------------------------------------------------------------------
 
-describe("PUT /api/prds/[id]/comments/[commentId]/resolve", () => {
+describe("PATCH /api/prds/[id]/comments/[commentId]/resolve", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRequireAuth.mockResolvedValue({
@@ -272,9 +272,9 @@ describe("PUT /api/prds/[id]/comments/[commentId]/resolve", () => {
   });
 
   it("should resolve a comment and return 200", async () => {
-    const response = await PUT(
+    const response = await PATCH(
       new Request("http://localhost/api/prds/prd_001/comments/comment_001/resolve", {
-        method: "PUT",
+        method: "PATCH",
       }) as any,
       makeResolveParams("prd_001", "comment_001") as any,
     );
@@ -293,9 +293,9 @@ describe("PUT /api/prds/[id]/comments/[commentId]/resolve", () => {
       new NotFoundError("Comment not found"),
     );
 
-    const response = await PUT(
+    const response = await PATCH(
       new Request("http://localhost/api/prds/prd_001/comments/nonexistent/resolve", {
-        method: "PUT",
+        method: "PATCH",
       }) as any,
       makeResolveParams("prd_001", "nonexistent") as any,
     );
@@ -308,9 +308,9 @@ describe("PUT /api/prds/[id]/comments/[commentId]/resolve", () => {
       new ForbiddenError("Only the PRD author, comment author, or an admin can resolve comments"),
     );
 
-    const response = await PUT(
+    const response = await PATCH(
       new Request("http://localhost/api/prds/prd_001/comments/comment_001/resolve", {
-        method: "PUT",
+        method: "PATCH",
       }) as any,
       makeResolveParams("prd_001", "comment_001") as any,
     );
@@ -323,9 +323,9 @@ describe("PUT /api/prds/[id]/comments/[commentId]/resolve", () => {
       new UnauthorizedError("Authentication required"),
     );
 
-    const response = await PUT(
+    const response = await PATCH(
       new Request("http://localhost/api/prds/prd_001/comments/comment_001/resolve", {
-        method: "PUT",
+        method: "PATCH",
       }) as any,
       makeResolveParams("prd_001", "comment_001") as any,
     );

--- a/src/app/api/prds/[id]/comments/route.ts
+++ b/src/app/api/prds/[id]/comments/route.ts
@@ -12,7 +12,23 @@ import { handleApiError, NotFoundError, ForbiddenError } from "@/lib/api/errors"
 import { validateBody } from "@/lib/api/validate";
 import { canAccessPrd } from "@/services/prd-access-service";
 import { listComments, createComment } from "@/services/comment-service";
+import type { ThreadedComment } from "@/services/comment-service";
+import type { CommentData } from "@/types/comments";
 import { prisma } from "@/lib/prisma";
+
+function toCommentData(c: ThreadedComment): CommentData {
+  return {
+    id: c.id,
+    authorId: c.authorId,
+    authorName: c.author.name ?? c.author.email,
+    body: c.body,
+    parentId: c.parentId ?? null,
+    resolved: c.resolved,
+    resolvedBy: c.resolvedBy ?? undefined,
+    createdAt: c.createdAt instanceof Date ? c.createdAt.toISOString() : c.createdAt,
+    replies: (c.replies ?? []).map(toCommentData),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -48,7 +64,7 @@ export async function GET(
     }
 
     const comments = await listComments(id);
-    return apiSuccess(comments);
+    return apiSuccess(comments.map(toCommentData));
   } catch (error) {
     return handleApiError(error);
   }
@@ -87,7 +103,7 @@ export async function POST(
       data.parentId,
     );
 
-    return apiSuccess(comment, 201);
+    return apiSuccess(toCommentData(comment), 201);
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/api/prds/[id]/generate/__tests__/route.test.ts
+++ b/src/app/api/prds/[id]/generate/__tests__/route.test.ts
@@ -106,7 +106,8 @@ describe("POST /api/prds/[id]/generate", () => {
     // Default: PRD exists and belongs to a project the user is a member of
     mockPrdFindUnique.mockResolvedValue({
       id: "prd_001",
-      title: "A short description for the PRD",
+      title: "My PRD Title",
+      description: "A short description for the PRD",
       projectId: "proj_001",
       authorId: "user_1",
       status: "DRAFT",
@@ -376,7 +377,7 @@ describe("POST /api/prds/[id]/generate", () => {
         mode: "create",
         projectId: "proj_001",
         prdId: "prd_001",
-        description: "A short description for the PRD",
+        description: "A short description for the PRD", // prd.description
       }),
     );
   });
@@ -458,7 +459,8 @@ describe("POST /api/prds/[id]/generate", () => {
   it("returns 409 when PRD is already being generated", async () => {
     mockPrdFindUnique.mockResolvedValue({
       id: "prd_001",
-      title: "A short description for the PRD",
+      title: "My PRD Title",
+      description: "A short description for the PRD",
       projectId: "proj_001",
       authorId: "user_1",
       status: "DRAFT",
@@ -478,7 +480,8 @@ describe("POST /api/prds/[id]/generate", () => {
   it("returns 409 when PRD generation has already completed", async () => {
     mockPrdFindUnique.mockResolvedValue({
       id: "prd_001",
-      title: "A short description for the PRD",
+      title: "My PRD Title",
+      description: "A short description for the PRD",
       projectId: "proj_001",
       authorId: "user_1",
       status: "DRAFT",

--- a/src/app/api/prds/[id]/generate/route.ts
+++ b/src/app/api/prds/[id]/generate/route.ts
@@ -78,7 +78,10 @@ export async function POST(
     });
 
     // Use shared prompt helper — prefer the stored description; fall back to title
-    const prompt = buildCreatePrompt(prd.description ?? prd.title);
+    const prompt = buildCreatePrompt(prd.description ?? prd.title, {
+      userId,
+      projectId: prd.projectId,
+    });
 
     logger.info(
       { sessionId, prdId, userId },

--- a/src/app/api/prds/[id]/generate/route.ts
+++ b/src/app/api/prds/[id]/generate/route.ts
@@ -74,11 +74,11 @@ export async function POST(
       mode: "create",
       projectId: prd.projectId,
       prdId: prd.id,
-      description: prd.title, // the description was saved as title initially
+      description: prd.description ?? prd.title,
     });
 
-    // Fix 5: Use shared prompt helper instead of inline duplicate
-    const prompt = buildCreatePrompt(prd.title);
+    // Use shared prompt helper — prefer the stored description; fall back to title
+    const prompt = buildCreatePrompt(prd.description ?? prd.title);
 
     logger.info(
       { sessionId, prdId, userId },

--- a/src/app/api/prds/__tests__/create-prd.test.ts
+++ b/src/app/api/prds/__tests__/create-prd.test.ts
@@ -89,7 +89,9 @@ describe("POST /api/prds", () => {
   });
 
   it("should create a PRD with valid data and return 201", async () => {
-    const response = await POST(postRequest({ projectId: "proj_001" }));
+    const response = await POST(
+      postRequest({ projectId: "proj_001", title: "Auth PRD" }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(201);
@@ -101,6 +103,7 @@ describe("POST /api/prds", () => {
     const response = await POST(
       postRequest({
         projectId: "proj_001",
+        title: "Auth PRD",
         description: "A new authentication PRD",
       }),
     );
@@ -114,6 +117,7 @@ describe("POST /api/prds", () => {
     await POST(
       postRequest({
         projectId: "proj_001",
+        title: "My PRD",
         description: "Some description",
       }),
     );
@@ -121,14 +125,24 @@ describe("POST /api/prds", () => {
     expect(mockPrdCreate).toHaveBeenCalledTimes(1);
     const createArg = mockPrdCreate.mock.calls[0][0];
     expect(createArg.data).toMatchObject({
+      title: "My PRD",
+      description: "Some description",
       projectId: "proj_001",
       authorId: "user_1",
       status: "DRAFT",
     });
   });
 
+  it("should return 422 when title is missing", async () => {
+    const response = await POST(postRequest({ projectId: "proj_001" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body).toHaveProperty("error");
+  });
+
   it("should return 422 when projectId is missing", async () => {
-    const response = await POST(postRequest({}));
+    const response = await POST(postRequest({ title: "My PRD" }));
     const body = await response.json();
 
     expect(response.status).toBe(422);
@@ -151,7 +165,9 @@ describe("POST /api/prds", () => {
       new UnauthorizedError("Authentication required"),
     );
 
-    const response = await POST(postRequest({ projectId: "proj_001" }));
+    const response = await POST(
+      postRequest({ projectId: "proj_001", title: "My PRD" }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(401);
@@ -161,7 +177,9 @@ describe("POST /api/prds", () => {
   it("should return 404 when project does not exist", async () => {
     mockProjectFindUnique.mockResolvedValue(null);
 
-    const response = await POST(postRequest({ projectId: "proj_999" }));
+    const response = await POST(
+      postRequest({ projectId: "proj_999", title: "My PRD" }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(404);
@@ -171,7 +189,9 @@ describe("POST /api/prds", () => {
   it("should return 403 when user is not a project member", async () => {
     mockProjectMemberFindUnique.mockResolvedValue(null);
 
-    const response = await POST(postRequest({ projectId: "proj_001" }));
+    const response = await POST(
+      postRequest({ projectId: "proj_001", title: "My PRD" }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(403);

--- a/src/app/api/prds/route.ts
+++ b/src/app/api/prds/route.ts
@@ -27,6 +27,7 @@ const ALLOWED_STATUSES = ["DRAFT", "IN_REVIEW", "APPROVED", "SUBMITTED"];
 
 const createPrdSchema = z.object({
   projectId: z.string().min(1, "projectId is required"),
+  title: z.string().min(1, "title is required"),
   description: z.string().optional(),
 });
 
@@ -150,9 +151,8 @@ export async function POST(request: NextRequest) {
     // Create the PRD in DRAFT status
     const prd = await prisma.prd.create({
       data: {
-        title: data.description
-          ? data.description.slice(0, 100)
-          : "Untitled PRD",
+        title: data.title,
+        description: data.description ?? null,
         projectId: data.projectId,
         authorId: userId,
         status: "DRAFT",

--- a/src/app/api/projects/[id]/__tests__/route.test.ts
+++ b/src/app/api/projects/[id]/__tests__/route.test.ts
@@ -62,7 +62,7 @@ const MOCK_PROJECT = {
   defaultLabels: [],
   defaultReviewers: [],
   members: [
-    { userId: "user_1", isReviewer: false, user: { id: "user_1", name: "Test User" } },
+    { userId: "user_1", role: "MEMBER", user: { id: "user_1", name: "Test User" } },
   ],
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/src/app/api/projects/[id]/members/[userId]/route.ts
+++ b/src/app/api/projects/[id]/members/[userId]/route.ts
@@ -1,13 +1,80 @@
 /**
  * /api/projects/[id]/members/[userId] - Individual member management.
  *
- * DELETE - Remove a member from a project (Admin only)
+ * PATCH  - Update member role (system ADMIN or project ADMIN)
+ * DELETE - Remove a member from a project (system ADMIN or project ADMIN)
  */
 import { type NextRequest } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { requireAdmin } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth";
 import { apiSuccess } from "@/lib/api/response";
-import { handleApiError, NotFoundError } from "@/lib/api/errors";
+import { handleApiError, NotFoundError, ForbiddenError } from "@/lib/api/errors";
+import { validateBody } from "@/lib/api/validate";
+
+// ---------------------------------------------------------------------------
+// Helper: check if user is system ADMIN or project ADMIN
+// ---------------------------------------------------------------------------
+
+async function requireProjectAdmin(projectId: string, userId: string, systemRole: string) {
+  if (systemRole === "ADMIN") return;
+  const membership = await prisma.projectMember.findUnique({
+    where: { projectId_userId: { projectId, userId } },
+  });
+  if (!membership || membership.role !== "ADMIN") {
+    throw new ForbiddenError("Only project admins or system admins can manage members");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const UpdateRoleSchema = z.object({
+  role: z.enum(["MEMBER", "REVIEWER", "SUBMITTER", "APPROVER", "ADMIN"]),
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/projects/[id]/members/[userId]
+// ---------------------------------------------------------------------------
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; userId: string }> },
+) {
+  try {
+    const session = await requireAuth();
+    const { id, userId: targetUserId } = await params;
+    const actingUserId = session.user.id;
+    const systemRole = session.user.role;
+
+    const project = await prisma.project.findUnique({ where: { id } });
+    if (!project) {
+      throw new NotFoundError("Project not found");
+    }
+
+    await requireProjectAdmin(id, actingUserId, systemRole);
+
+    const membership = await prisma.projectMember.findUnique({
+      where: { projectId_userId: { projectId: id, userId: targetUserId } },
+    });
+    if (!membership) {
+      throw new NotFoundError("Membership not found");
+    }
+
+    const data = await validateBody(UpdateRoleSchema, request);
+
+    const updated = await prisma.projectMember.update({
+      where: { projectId_userId: { projectId: id, userId: targetUserId } },
+      data: { role: data.role },
+      include: { user: { select: { id: true, name: true, email: true, avatarUrl: true, role: true } } },
+    });
+
+    return apiSuccess(updated);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // DELETE /api/projects/[id]/members/[userId]
@@ -18,19 +85,22 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string; userId: string }> },
 ) {
   try {
-    await requireAdmin();
-    const { id, userId } = await params;
+    const session = await requireAuth();
+    const { id, userId: targetUserId } = await params;
+    const actingUserId = session.user.id;
+    const systemRole = session.user.role;
+
+    await requireProjectAdmin(id, actingUserId, systemRole);
 
     const membership = await prisma.projectMember.findUnique({
-      where: { projectId_userId: { projectId: id, userId } },
+      where: { projectId_userId: { projectId: id, userId: targetUserId } },
     });
-
     if (!membership) {
       throw new NotFoundError("Membership not found");
     }
 
     await prisma.projectMember.delete({
-      where: { projectId_userId: { projectId: id, userId } },
+      where: { projectId_userId: { projectId: id, userId: targetUserId } },
     });
 
     return apiSuccess({ deleted: true });

--- a/src/app/api/projects/[id]/members/__tests__/route.test.ts
+++ b/src/app/api/projects/[id]/members/__tests__/route.test.ts
@@ -2,7 +2,8 @@
  * Project members API route tests.
  *
  * Tests for GET /api/projects/[id]/members (list),
- * POST /api/projects/[id]/members (add member),
+ * POST /api/projects/[id]/members (add member by email),
+ * PATCH /api/projects/[id]/members/[userId] (update role),
  * and DELETE /api/projects/[id]/members/[userId] (remove member).
  */
 
@@ -14,6 +15,7 @@ const mockProjectFindUnique = jest.fn();
 const mockProjectMemberFindUnique = jest.fn();
 const mockProjectMemberFindMany = jest.fn();
 const mockProjectMemberCreate = jest.fn();
+const mockProjectMemberUpdate = jest.fn();
 const mockProjectMemberDelete = jest.fn();
 const mockUserFindUnique = jest.fn();
 
@@ -26,6 +28,7 @@ jest.mock("@/lib/prisma", () => ({
       findUnique: (...args: unknown[]) => mockProjectMemberFindUnique(...args),
       findMany: (...args: unknown[]) => mockProjectMemberFindMany(...args),
       create: (...args: unknown[]) => mockProjectMemberCreate(...args),
+      update: (...args: unknown[]) => mockProjectMemberUpdate(...args),
       delete: (...args: unknown[]) => mockProjectMemberDelete(...args),
     },
     user: {
@@ -35,11 +38,9 @@ jest.mock("@/lib/prisma", () => ({
 }));
 
 const mockRequireAuth = jest.fn();
-const mockRequireAdmin = jest.fn();
 
 jest.mock("@/lib/auth", () => ({
   requireAuth: () => mockRequireAuth(),
-  requireAdmin: () => mockRequireAdmin(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -47,8 +48,8 @@ jest.mock("@/lib/auth", () => ({
 // ---------------------------------------------------------------------------
 
 import { GET, POST } from "../route";
-import { DELETE } from "../[userId]/route";
-import { UnauthorizedError, ForbiddenError } from "@/lib/api/errors";
+import { PATCH, DELETE } from "../[userId]/route";
+import { ForbiddenError } from "@/lib/api/errors";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -58,13 +59,21 @@ function makeMemberParams(id: string) {
   return { params: Promise.resolve({ id }) };
 }
 
-function makeDeleteParams(id: string, userId: string) {
+function makeUserParams(id: string, userId: string) {
   return { params: Promise.resolve({ id, userId }) };
 }
 
 function postRequest(body: Record<string, unknown>): Request {
   return new Request("http://localhost/api/projects/proj_001/members", {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function patchRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/projects/proj_001/members/user_1", {
+    method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
@@ -77,15 +86,15 @@ const MOCK_MEMBERS = [
     id: "pm_1",
     projectId: "proj_001",
     userId: "user_1",
-    isReviewer: false,
-    user: { id: "user_1", name: "User One", email: "one@example.com" },
+    role: "MEMBER",
+    user: { id: "user_1", name: "User One", email: "one@example.com", avatarUrl: null, role: "AUTHOR" },
   },
   {
     id: "pm_2",
     projectId: "proj_001",
     userId: "user_2",
-    isReviewer: true,
-    user: { id: "user_2", name: "User Two", email: "two@example.com" },
+    role: "REVIEWER",
+    user: { id: "user_2", name: "User Two", email: "two@example.com", avatarUrl: null, role: "AUTHOR" },
   },
 ];
 
@@ -100,7 +109,9 @@ describe("GET /api/projects/[id]/members", () => {
       user: { id: "user_1", email: "test@example.com", role: "AUTHOR" },
     });
     mockProjectFindUnique.mockResolvedValue(MOCK_PROJECT);
-    mockProjectMemberFindUnique.mockResolvedValue({ id: "pm_1", projectId: "proj_001", userId: "user_1" });
+    mockProjectMemberFindUnique.mockResolvedValue({
+      id: "pm_1", projectId: "proj_001", userId: "user_1", role: "MEMBER",
+    });
     mockProjectMemberFindMany.mockResolvedValue(MOCK_MEMBERS);
   });
 
@@ -117,7 +128,7 @@ describe("GET /api/projects/[id]/members", () => {
     expect(body.data).toHaveLength(2);
   });
 
-  it("should return members for ADMIN regardless of membership", async () => {
+  it("should return members for system ADMIN regardless of membership", async () => {
     mockRequireAuth.mockResolvedValue({
       user: { id: "user_admin", email: "admin@example.com", role: "ADMIN" },
     });
@@ -130,7 +141,7 @@ describe("GET /api/projects/[id]/members", () => {
 
     expect(response.status).toBe(200);
     expect(body.data).toHaveLength(2);
-    // Should not check membership for admin
+    // Should not check membership for system admin
     expect(mockProjectMemberFindUnique).not.toHaveBeenCalled();
   });
 
@@ -164,44 +175,47 @@ describe("GET /api/projects/[id]/members", () => {
 describe("POST /api/projects/[id]/members", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockRequireAdmin.mockResolvedValue({
+    // System admin session
+    mockRequireAuth.mockResolvedValue({
       user: { id: "user_admin", email: "admin@example.com", role: "ADMIN" },
     });
     mockProjectFindUnique.mockResolvedValue(MOCK_PROJECT);
-    mockUserFindUnique.mockResolvedValue({ id: "user_3", name: "User Three" });
+    mockUserFindUnique.mockResolvedValue({
+      id: "user_3", name: "User Three", email: "three@example.com",
+    });
     mockProjectMemberFindUnique.mockResolvedValue(null); // Not already a member
     mockProjectMemberCreate.mockResolvedValue({
       id: "pm_new",
       projectId: "proj_001",
       userId: "user_3",
-      isReviewer: false,
-      user: { id: "user_3", name: "User Three" },
+      role: "MEMBER",
+      user: { id: "user_3", name: "User Three", email: "three@example.com", avatarUrl: null, role: "AUTHOR" },
     });
   });
 
-  it("should add a member and return 201", async () => {
+  it("should add a member by email and return 201", async () => {
     const response = await POST(
-      postRequest({ userId: "user_3" }) as any,
+      postRequest({ email: "three@example.com" }) as any,
       makeMemberParams("proj_001") as any,
     );
     const body = await response.json();
 
     expect(response.status).toBe(201);
     expect(body.data).toHaveProperty("userId", "user_3");
-    expect(body.data).toHaveProperty("isReviewer", false);
+    expect(body.data).toHaveProperty("role", "MEMBER");
   });
 
-  it("should add a reviewer member", async () => {
+  it("should add a member with a specific role", async () => {
     mockProjectMemberCreate.mockResolvedValue({
       id: "pm_new",
       projectId: "proj_001",
       userId: "user_3",
-      isReviewer: true,
-      user: { id: "user_3", name: "User Three" },
+      role: "APPROVER",
+      user: { id: "user_3", name: "User Three", email: "three@example.com", avatarUrl: null, role: "AUTHOR" },
     });
 
     const response = await POST(
-      postRequest({ userId: "user_3", isReviewer: true }) as any,
+      postRequest({ email: "three@example.com", role: "APPROVER" }) as any,
       makeMemberParams("proj_001") as any,
     );
     const body = await response.json();
@@ -209,18 +223,22 @@ describe("POST /api/projects/[id]/members", () => {
     expect(response.status).toBe(201);
     expect(mockProjectMemberCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ isReviewer: true }),
+        data: expect.objectContaining({ role: "APPROVER" }),
       }),
     );
   });
 
-  it("should return 403 for non-admin", async () => {
-    mockRequireAdmin.mockRejectedValue(
-      new ForbiddenError("Insufficient permissions"),
-    );
+  it("should return 403 for non-admin non-project-admin", async () => {
+    mockRequireAuth.mockResolvedValue({
+      user: { id: "user_member", email: "member@example.com", role: "AUTHOR" },
+    });
+    // User has MEMBER role — not a project admin
+    mockProjectMemberFindUnique.mockResolvedValue({
+      id: "pm_1", projectId: "proj_001", userId: "user_member", role: "MEMBER",
+    });
 
     const response = await POST(
-      postRequest({ userId: "user_3" }) as any,
+      postRequest({ email: "three@example.com" }) as any,
       makeMemberParams("proj_001") as any,
     );
 
@@ -231,18 +249,18 @@ describe("POST /api/projects/[id]/members", () => {
     mockProjectFindUnique.mockResolvedValue(null);
 
     const response = await POST(
-      postRequest({ userId: "user_3" }) as any,
+      postRequest({ email: "three@example.com" }) as any,
       makeMemberParams("proj_999") as any,
     );
 
     expect(response.status).toBe(404);
   });
 
-  it("should return 404 when user does not exist", async () => {
+  it("should return 404 when user with email does not exist", async () => {
     mockUserFindUnique.mockResolvedValue(null);
 
     const response = await POST(
-      postRequest({ userId: "user_nonexistent" }) as any,
+      postRequest({ email: "nobody@example.com" }) as any,
       makeMemberParams("proj_001") as any,
     );
 
@@ -250,14 +268,13 @@ describe("POST /api/projects/[id]/members", () => {
   });
 
   it("should return 409 when user is already a member", async () => {
+    // System admin skips requireProjectAdmin; only the duplicate check calls findUnique
     mockProjectMemberFindUnique.mockResolvedValue({
-      id: "pm_existing",
-      projectId: "proj_001",
-      userId: "user_3",
+      id: "pm_existing", projectId: "proj_001", userId: "user_3",
     });
 
     const response = await POST(
-      postRequest({ userId: "user_3" }) as any,
+      postRequest({ email: "three@example.com" }) as any,
       makeMemberParams("proj_001") as any,
     );
     const body = await response.json();
@@ -266,7 +283,7 @@ describe("POST /api/projects/[id]/members", () => {
     expect(body.error).toContain("already a member");
   });
 
-  it("should return 422 when userId is missing", async () => {
+  it("should return 422 when email is missing", async () => {
     const response = await POST(
       postRequest({}) as any,
       makeMemberParams("proj_001") as any,
@@ -277,19 +294,87 @@ describe("POST /api/projects/[id]/members", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: PATCH /api/projects/[id]/members/[userId]
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/projects/[id]/members/[userId]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({
+      user: { id: "user_admin", email: "admin@example.com", role: "ADMIN" },
+    });
+    mockProjectFindUnique.mockResolvedValue(MOCK_PROJECT);
+    mockProjectMemberFindUnique.mockResolvedValue({
+      id: "pm_1", projectId: "proj_001", userId: "user_1", role: "MEMBER",
+    });
+    mockProjectMemberUpdate.mockResolvedValue({
+      id: "pm_1",
+      projectId: "proj_001",
+      userId: "user_1",
+      role: "REVIEWER",
+      user: { id: "user_1", name: "User One", email: "one@example.com", avatarUrl: null, role: "AUTHOR" },
+    });
+  });
+
+  it("should update member role and return 200", async () => {
+    const response = await PATCH(
+      patchRequest({ role: "REVIEWER" }) as any,
+      makeUserParams("proj_001", "user_1") as any,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveProperty("role", "REVIEWER");
+    expect(mockProjectMemberUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { role: "REVIEWER" },
+      }),
+    );
+  });
+
+  it("should return 404 when membership does not exist", async () => {
+    mockProjectMemberFindUnique.mockResolvedValue(null);
+
+    const response = await PATCH(
+      patchRequest({ role: "REVIEWER" }) as any,
+      makeUserParams("proj_001", "user_999") as any,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 403 for non-admin without project admin role", async () => {
+    mockRequireAuth.mockResolvedValue({
+      user: { id: "user_member", email: "member@example.com", role: "AUTHOR" },
+    });
+    mockProjectMemberFindUnique.mockResolvedValue({
+      id: "pm_x", projectId: "proj_001", userId: "user_member", role: "MEMBER",
+    });
+
+    const response = await PATCH(
+      patchRequest({ role: "REVIEWER" }) as any,
+      makeUserParams("proj_001", "user_1") as any,
+    );
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: DELETE /api/projects/[id]/members/[userId]
 // ---------------------------------------------------------------------------
 
 describe("DELETE /api/projects/[id]/members/[userId]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockRequireAdmin.mockResolvedValue({
+    mockRequireAuth.mockResolvedValue({
       user: { id: "user_admin", email: "admin@example.com", role: "ADMIN" },
     });
     mockProjectMemberFindUnique.mockResolvedValue({
       id: "pm_1",
       projectId: "proj_001",
       userId: "user_1",
+      role: "MEMBER",
     });
     mockProjectMemberDelete.mockResolvedValue({
       id: "pm_1",
@@ -303,7 +388,7 @@ describe("DELETE /api/projects/[id]/members/[userId]", () => {
       new Request("http://localhost/api/projects/proj_001/members/user_1", {
         method: "DELETE",
       }) as any,
-      makeDeleteParams("proj_001", "user_1") as any,
+      makeUserParams("proj_001", "user_1") as any,
     );
     const body = await response.json();
 
@@ -321,22 +406,25 @@ describe("DELETE /api/projects/[id]/members/[userId]", () => {
       new Request("http://localhost/api/projects/proj_001/members/user_999", {
         method: "DELETE",
       }) as any,
-      makeDeleteParams("proj_001", "user_999") as any,
+      makeUserParams("proj_001", "user_999") as any,
     );
 
     expect(response.status).toBe(404);
   });
 
-  it("should return 403 for non-admin", async () => {
-    mockRequireAdmin.mockRejectedValue(
-      new ForbiddenError("Insufficient permissions"),
-    );
+  it("should return 403 for non-admin without project admin role", async () => {
+    mockRequireAuth.mockResolvedValue({
+      user: { id: "user_member", email: "member@example.com", role: "AUTHOR" },
+    });
+    mockProjectMemberFindUnique.mockResolvedValue({
+      id: "pm_x", projectId: "proj_001", userId: "user_member", role: "MEMBER",
+    });
 
     const response = await DELETE(
       new Request("http://localhost/api/projects/proj_001/members/user_1", {
         method: "DELETE",
       }) as any,
-      makeDeleteParams("proj_001", "user_1") as any,
+      makeUserParams("proj_001", "user_1") as any,
     );
 
     expect(response.status).toBe(403);

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -1,13 +1,13 @@
 /**
  * /api/projects/[id]/members - Project member management API routes.
  *
- * GET  - List project members (authenticated, member or ADMIN)
- * POST - Add member to project (Admin only)
+ * GET  - List project members (authenticated, member or system ADMIN)
+ * POST - Add member to project (system ADMIN or project ADMIN)
  */
 import { type NextRequest } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { requireAuth, requireAdmin } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth";
 import { apiSuccess } from "@/lib/api/response";
 import { handleApiError, NotFoundError, ForbiddenError } from "@/lib/api/errors";
 import { validateBody } from "@/lib/api/validate";
@@ -18,9 +18,23 @@ import { ApiError } from "@/lib/api/errors";
 // ---------------------------------------------------------------------------
 
 const AddMemberSchema = z.object({
-  userId: z.string().min(1),
-  isReviewer: z.boolean().optional().default(false),
+  email: z.string().email(),
+  role: z.enum(["MEMBER", "REVIEWER", "SUBMITTER", "APPROVER", "ADMIN"]).optional().default("MEMBER"),
 });
+
+// ---------------------------------------------------------------------------
+// Helper: check if user is system ADMIN or project ADMIN
+// ---------------------------------------------------------------------------
+
+async function requireProjectAdmin(projectId: string, userId: string, systemRole: string) {
+  if (systemRole === "ADMIN") return;
+  const membership = await prisma.projectMember.findUnique({
+    where: { projectId_userId: { projectId, userId } },
+  });
+  if (!membership || membership.role !== "ADMIN") {
+    throw new ForbiddenError("Only project admins or system admins can manage members");
+  }
+}
 
 // ---------------------------------------------------------------------------
 // GET /api/projects/[id]/members
@@ -34,15 +48,15 @@ export async function GET(
     const session = await requireAuth();
     const { id } = await params;
     const userId = session.user.id;
-    const role = session.user.role;
+    const systemRole = session.user.role;
 
     const project = await prisma.project.findUnique({ where: { id } });
     if (!project) {
       throw new NotFoundError("Project not found");
     }
 
-    // Non-admins must be a member
-    if (role !== "ADMIN") {
+    // Non-system-admins must be a member
+    if (systemRole !== "ADMIN") {
       const membership = await prisma.projectMember.findUnique({
         where: { projectId_userId: { projectId: id, userId } },
       });
@@ -53,7 +67,8 @@ export async function GET(
 
     const members = await prisma.projectMember.findMany({
       where: { projectId: id },
-      include: { user: true },
+      include: { user: { select: { id: true, name: true, email: true, avatarUrl: true, role: true } } },
+      orderBy: { user: { name: "asc" } },
     });
 
     return apiSuccess(members);
@@ -71,25 +86,29 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    await requireAdmin();
+    const session = await requireAuth();
     const { id } = await params;
+    const userId = session.user.id;
+    const systemRole = session.user.role;
 
     const project = await prisma.project.findUnique({ where: { id } });
     if (!project) {
       throw new NotFoundError("Project not found");
     }
 
+    await requireProjectAdmin(id, userId, systemRole);
+
     const data = await validateBody(AddMemberSchema, request);
 
-    // Check if user exists
-    const user = await prisma.user.findUnique({ where: { id: data.userId } });
-    if (!user) {
-      throw new NotFoundError("User not found");
+    // Find user by email
+    const targetUser = await prisma.user.findUnique({ where: { email: data.email } });
+    if (!targetUser) {
+      throw new NotFoundError("No user found with that email address");
     }
 
     // Check if already a member
     const existing = await prisma.projectMember.findUnique({
-      where: { projectId_userId: { projectId: id, userId: data.userId } },
+      where: { projectId_userId: { projectId: id, userId: targetUser.id } },
     });
     if (existing) {
       throw new ApiError("User is already a member of this project", 409);
@@ -98,10 +117,10 @@ export async function POST(
     const member = await prisma.projectMember.create({
       data: {
         projectId: id,
-        userId: data.userId,
-        isReviewer: data.isReviewer,
+        userId: targetUser.id,
+        role: data.role,
       },
-      include: { user: true },
+      include: { user: { select: { id: true, name: true, email: true, avatarUrl: true, role: true } } },
     });
 
     return apiSuccess(member, 201);

--- a/src/app/api/projects/__tests__/route.test.ts
+++ b/src/app/api/projects/__tests__/route.test.ts
@@ -197,6 +197,7 @@ describe("POST /api/projects", () => {
         members: {
           create: {
             userId: "user_1",
+            role: "ADMIN",
           },
         },
       },

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -92,6 +92,7 @@ export async function POST(request: NextRequest) {
         members: {
           create: {
             userId: session.user.id,
+            role: "ADMIN",
           },
         },
       },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,8 +33,8 @@
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 0 0% 100%;
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
     --muted: 217.2 32.6% 17.5%;

--- a/src/app/prd/[id]/page.tsx
+++ b/src/app/prd/[id]/page.tsx
@@ -21,6 +21,7 @@ import { StatusBadge } from "@/components/workflow/StatusBadge";
 import { TransitionButtons } from "@/components/workflow/TransitionButtons";
 import { SubmissionModal } from "@/components/submission/SubmissionModal";
 import { usePrdGeneration } from "@/hooks/usePrdGeneration";
+import { CommentsList } from "@/components/comments";
 
 // ---------------------------------------------------------------------------
 // Status mapping: Prisma enum ↔ display strings used by workflow components
@@ -234,10 +235,8 @@ export default function PrdDetailPage() {
         )}
 
         {activeTab === "Comments" && (
-          <div>
-            <p className="text-muted-foreground">
-              Comments and review feedback will appear here.
-            </p>
+          <div className="px-1 py-4">
+            <CommentsList prdId={prdId} />
           </div>
         )}
 

--- a/src/app/prd/[id]/page.tsx
+++ b/src/app/prd/[id]/page.tsx
@@ -125,7 +125,7 @@ export default function PrdDetailPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <StatusBadge status={displayStatus} />
-          <h1 className="text-2xl font-bold">{title || "PRD Detail"}</h1>
+          <h1 className="min-w-0 flex-1 truncate text-2xl font-bold" title={title || "PRD Detail"}>{title || "PRD Detail"}</h1>
         </div>
         <div className="flex items-center gap-2">
           <TransitionButtons
@@ -177,8 +177,8 @@ export default function PrdDetailPage() {
           <>
             {/* Generation error state */}
             {generationError && (
-              <div className="mb-4 rounded border border-red-200 bg-red-50 p-4">
-                <p className="text-sm font-medium text-red-800">
+              <div className="mb-4 rounded border border-red-500/30 bg-red-500/10 p-4">
+                <p className="text-sm font-medium text-red-400">
                   Generation failed: {generationError}
                 </p>
                 <button
@@ -193,9 +193,9 @@ export default function PrdDetailPage() {
             {/* Generation in progress */}
             {isGenerating && (
               <div className="mb-4">
-                <div className="flex items-center gap-2 rounded border border-blue-200 bg-blue-50 p-3">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
-                  <span className="text-sm font-medium text-blue-800">
+                <div className="flex items-center gap-2 rounded border border-blue-500/30 bg-blue-500/10 p-3">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-blue-400 border-t-transparent" />
+                  <span className="text-sm font-medium text-blue-400">
                     Generating PRD content...
                   </span>
                 </div>

--- a/src/app/prd/new/page.tsx
+++ b/src/app/prd/new/page.tsx
@@ -13,6 +13,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+import ReactMarkdown from "react-markdown";
 
 interface Project {
   id: string;
@@ -30,6 +31,7 @@ export default function NewPrdPage() {
   const [streamingText, setStreamingText] = useState("");
   const [error, setError] = useState<string | null>(null);
 
+  const [descTab, setDescTab] = useState<"write" | "preview">("write");
   const streamingPreviewRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -184,92 +186,131 @@ export default function NewPrdPage() {
   }
 
   return (
-    <main className="mx-auto max-w-2xl p-8">
-      <h1 className="text-2xl font-bold">New PRD</h1>
-      <p className="mt-2 text-muted-foreground">
-        Create a new PRD with AI-assisted authoring.
-      </p>
+    <main className="flex h-[calc(100vh-3.5rem)] flex-col p-6 gap-4">
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-4 shrink-0">
+        <div>
+          <h1 className="text-2xl font-bold">New PRD</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Create a new PRD with AI-assisted authoring.
+          </p>
+        </div>
+        {!isGenerating && (
+          <button
+            onClick={handleStart}
+            disabled={isSubmitting}
+            className="rounded bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90 disabled:opacity-50 whitespace-nowrap"
+          >
+            {isSubmitting ? "Creating..." : "Start"}
+          </button>
+        )}
+      </div>
 
       {error && (
-        <p className="mt-4 text-sm text-red-600" role="alert">
+        <p className="text-sm text-red-600 shrink-0" role="alert">
           {error}
         </p>
       )}
 
       {isGenerating ? (
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold">Generating your PRD...</h2>
-          <p className="text-sm text-muted-foreground">
-            This may take a moment.
-          </p>
+        <div className="flex flex-col flex-1 min-h-0">
+          <h2 className="text-lg font-semibold shrink-0">Generating your PRD...</h2>
+          <p className="text-sm text-muted-foreground shrink-0">This may take a moment.</p>
           {streamingText && (
             <div
               ref={streamingPreviewRef}
-              className="mt-4 rounded border border-border bg-muted p-4 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto"
+              className="mt-4 flex-1 min-h-0 overflow-y-auto rounded border border-border bg-muted p-4 text-sm font-mono whitespace-pre-wrap"
             >
               {streamingText}
             </div>
           )}
         </div>
       ) : (
-        <div className="mt-6 space-y-4">
-          <div>
-            <label
-              htmlFor="project-select"
-              className="block text-sm font-medium"
-            >
-              Project
-            </label>
-            <select
-              id="project-select"
-              value={projectId}
-              onChange={(e) => setProjectId(e.target.value)}
-              className="mt-1 block w-full rounded border border-input bg-background p-2 text-foreground"
-            >
-              <option value="">Select a project...</option>
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
+        <div className="flex flex-col flex-1 min-h-0 gap-3">
+          {/* Project + Title column */}
+          <div className="flex flex-col gap-3 shrink-0">
+            <div>
+              <label htmlFor="project-select" className="block text-sm font-medium mb-1">
+                Project
+              </label>
+              <select
+                id="project-select"
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+                className="block w-full rounded border border-input bg-background p-2 text-foreground text-sm"
+              >
+                <option value="">Select a project...</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="prd-title" className="block text-sm font-medium mb-1">
+                Title <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="prd-title"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Short name for this PRD"
+                className="block w-full rounded border border-input bg-background p-2 text-foreground placeholder:text-muted-foreground text-sm"
+              />
+            </div>
           </div>
 
-          <div>
-            <label htmlFor="prd-title" className="block text-sm font-medium">
-              Title <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="prd-title"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Short name for this PRD"
-              className="mt-1 block w-full rounded border border-input bg-background p-2 text-foreground placeholder:text-muted-foreground"
-            />
-          </div>
+          {/* Markdown editor — fills remaining height */}
+          <div className="flex flex-col flex-1 min-h-0">
+            {/* Tab bar */}
+            <div className="flex items-center gap-1 border-b border-border shrink-0 mb-0">
+              <button
+                type="button"
+                onClick={() => setDescTab("write")}
+                className={`px-3 py-1.5 text-sm font-medium border-b-2 transition-colors ${
+                  descTab === "write"
+                    ? "border-primary text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Write
+              </button>
+              <button
+                type="button"
+                onClick={() => setDescTab("preview")}
+                className={`px-3 py-1.5 text-sm font-medium border-b-2 transition-colors ${
+                  descTab === "preview"
+                    ? "border-primary text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Preview
+              </button>
+              <span className="ml-auto text-xs text-muted-foreground pr-1">Markdown supported</span>
+            </div>
 
-          <div>
-            <label htmlFor="description" className="block text-sm font-medium">
-              Description
-            </label>
-            <textarea
-              id="description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={4}
-              placeholder="Briefly describe what this PRD should cover..."
-              className="mt-1 block w-full rounded border border-input bg-background p-2 text-foreground placeholder:text-muted-foreground"
-            />
+            {descTab === "write" ? (
+              <textarea
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe what this PRD should cover. Supports **markdown** formatting."
+                className="flex-1 min-h-0 w-full resize-none rounded-b border border-t-0 border-input bg-background p-3 text-sm text-foreground placeholder:text-muted-foreground font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            ) : (
+              <div className="flex-1 min-h-0 overflow-y-auto rounded-b border border-t-0 border-border bg-background p-4">
+                {description ? (
+                  <div className="prose prose-sm dark:prose-invert max-w-none">
+                    <ReactMarkdown>{description}</ReactMarkdown>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground italic">Nothing to preview yet.</p>
+                )}
+              </div>
+            )}
           </div>
-
-          <button
-            onClick={handleStart}
-            disabled={isSubmitting}
-            className="rounded bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-          >
-            {isSubmitting ? "Creating..." : "Start"}
-          </button>
         </div>
       )}
     </main>

--- a/src/app/prd/new/page.tsx
+++ b/src/app/prd/new/page.tsx
@@ -23,6 +23,7 @@ export default function NewPrdPage() {
   const router = useRouter();
   const [projects, setProjects] = useState<Project[]>([]);
   const [projectId, setProjectId] = useState("");
+  const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -66,6 +67,10 @@ export default function NewPrdPage() {
       setError("Please select a project");
       return;
     }
+    if (!title.trim()) {
+      setError("Please enter a title");
+      return;
+    }
 
     setStreamingText("");
     setIsSubmitting(true);
@@ -78,7 +83,7 @@ export default function NewPrdPage() {
       const res = await fetch("/api/prds", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ projectId, description }),
+        body: JSON.stringify({ projectId, title: title.trim(), description }),
       });
 
       if (!res.ok) {
@@ -228,6 +233,20 @@ export default function NewPrdPage() {
                 </option>
               ))}
             </select>
+          </div>
+
+          <div>
+            <label htmlFor="prd-title" className="block text-sm font-medium">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="prd-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Short name for this PRD"
+              className="mt-1 block w-full rounded border border-input bg-background p-2 text-foreground placeholder:text-muted-foreground"
+            />
           </div>
 
           <div>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,55 +1,159 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import React, { useEffect, useState, useCallback } from "react";
+import { useParams } from "next/navigation";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
+
+type ProjectRole = "MEMBER" | "REVIEWER" | "SUBMITTER" | "APPROVER" | "ADMIN";
+
+interface MemberUser {
+  id: string;
+  name: string | null;
+  email: string;
+  avatarUrl: string | null;
+}
 
 interface Member {
   id: string;
-  user: { name: string; email: string };
-  role: string;
-  isReviewer: boolean;
+  userId: string;
+  projectId: string;
+  role: ProjectRole;
+  user: MemberUser;
 }
 
 interface ProjectDetail {
   id: string;
   name: string;
-  description: string;
+  description: string | null;
   githubRepo: string;
   defaultLabels: string[];
   defaultReviewers: string[];
-  members: Member[];
 }
+
+const ROLE_LABELS: Record<ProjectRole, string> = {
+  MEMBER: "Member",
+  REVIEWER: "Reviewer",
+  SUBMITTER: "Submitter",
+  APPROVER: "Approver",
+  ADMIN: "Admin",
+};
+
+const ROLE_COLORS: Record<ProjectRole, string> = {
+  MEMBER: "bg-secondary text-secondary-foreground",
+  REVIEWER: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+  SUBMITTER: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+  APPROVER: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+  ADMIN: "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
+};
 
 export default function ProjectDetailPage() {
   const params = useParams();
-  const router = useRouter();
   const projectId = params.id as string;
+  const { data: session } = useSession();
 
   const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Add member form state
+  const [addEmail, setAddEmail] = useState("");
+  const [addRole, setAddRole] = useState<ProjectRole>("MEMBER");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [addLoading, setAddLoading] = useState(false);
+
+  // Role update state
+  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null);
+
+  const currentUserId = session?.user?.id ?? "";
+  const isSystemAdmin = session?.user?.role === "ADMIN";
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/projects/${projectId}/members`);
+      if (!res.ok) return;
+      const json = await res.json();
+      setMembers(json.data ?? []);
+    } catch {
+      // ignore
+    }
+  }, [projectId]);
 
   useEffect(() => {
     async function fetchProject() {
       try {
         const res = await fetch(`/api/projects/${projectId}`);
-        if (!res.ok) {
-          throw new Error("Failed to load project");
-        }
+        if (!res.ok) throw new Error("Failed to load project");
         const json = await res.json();
         setProject(json.data);
       } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to load project",
-        );
+        setError(err instanceof Error ? err.message : "Failed to load project");
       } finally {
         setIsLoading(false);
       }
     }
-
     fetchProject();
-  }, [projectId]);
+    fetchMembers();
+  }, [projectId, fetchMembers]);
+
+  // Determine if current user is a project ADMIN (or system ADMIN)
+  const myMembership = members.find((m) => m.userId === currentUserId);
+  const isProjectAdmin = isSystemAdmin || myMembership?.role === "ADMIN";
+
+  async function handleAddMember(e: React.FormEvent) {
+    e.preventDefault();
+    if (!addEmail.trim()) return;
+    setAddLoading(true);
+    setAddError(null);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: addEmail.trim(), role: addRole }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setAddError(json.error ?? "Failed to add member");
+        return;
+      }
+      setAddEmail("");
+      setAddRole("MEMBER");
+      await fetchMembers();
+    } catch {
+      setAddError("Network error. Please try again.");
+    } finally {
+      setAddLoading(false);
+    }
+  }
+
+  async function handleRoleChange(targetUserId: string, newRole: ProjectRole) {
+    setUpdatingUserId(targetUserId);
+    try {
+      await fetch(`/api/projects/${projectId}/members/${targetUserId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: newRole }),
+      });
+      await fetchMembers();
+    } finally {
+      setUpdatingUserId(null);
+    }
+  }
+
+  async function handleRemove(targetUserId: string) {
+    if (!confirm("Remove this member from the project?")) return;
+    setRemovingUserId(targetUserId);
+    try {
+      await fetch(`/api/projects/${projectId}/members/${targetUserId}`, {
+        method: "DELETE",
+      });
+      await fetchMembers();
+    } finally {
+      setRemovingUserId(null);
+    }
+  }
 
   if (isLoading) {
     return (
@@ -62,110 +166,155 @@ export default function ProjectDetailPage() {
   if (error || !project) {
     return (
       <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-        <div className="rounded-md bg-red-50 p-4" role="alert">
-          <p className="text-sm text-red-700">
-            {error ?? "Project not found"}
-          </p>
+        <div className="rounded-md bg-destructive/10 p-4" role="alert">
+          <p className="text-sm text-destructive">{error ?? "Project not found"}</p>
         </div>
       </main>
     );
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8 space-y-8">
+      {/* Header */}
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-foreground">{project.name}</h1>
-        <Link
-          href={`/projects/${projectId}/edit`}
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-        >
-          Edit Project
-        </Link>
+        {isSystemAdmin && (
+          <Link
+            href={`/projects/${projectId}/edit`}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+          >
+            Edit Project
+          </Link>
+        )}
       </div>
 
       {project.description && (
-        <p className="mt-4 text-muted-foreground">{project.description}</p>
+        <p className="text-muted-foreground">{project.description}</p>
       )}
 
-      <section className="mt-8" aria-labelledby="github-heading">
-        <h2
-          id="github-heading"
-          className="text-lg font-semibold text-foreground"
-        >
+      {/* GitHub Settings */}
+      <section aria-labelledby="github-heading">
+        <h2 id="github-heading" className="text-lg font-semibold text-foreground">
           GitHub Settings
         </h2>
         <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="rounded-md border border-border p-4">
-            <dt className="text-sm font-medium text-muted-foreground">
-              GitHub Repository
-            </dt>
-            <dd className="mt-1 text-sm text-foreground">
-              {project.githubRepo}
-            </dd>
+            <dt className="text-sm font-medium text-muted-foreground">GitHub Repository</dt>
+            <dd className="mt-1 text-sm text-foreground">{project.githubRepo}</dd>
           </div>
           <div className="rounded-md border border-border p-4">
             <dt className="text-sm font-medium text-muted-foreground">Default Labels</dt>
             <dd className="mt-1 text-sm text-foreground">
-              {project.defaultLabels.length > 0
-                ? project.defaultLabels.join(", ")
-                : "None"}
+              {project.defaultLabels.length > 0 ? project.defaultLabels.join(", ") : "None"}
             </dd>
           </div>
           <div className="rounded-md border border-border p-4">
             <dt className="text-sm font-medium text-muted-foreground">Default Reviewers</dt>
             <dd className="mt-1 text-sm text-foreground">
-              {project.defaultReviewers.length > 0
-                ? project.defaultReviewers.join(", ")
-                : "None"}
+              {project.defaultReviewers.length > 0 ? project.defaultReviewers.join(", ") : "None"}
             </dd>
           </div>
         </dl>
       </section>
 
-      <section className="mt-8" aria-labelledby="members-heading">
-        <div className="flex items-center justify-between">
-          <h2
-            id="members-heading"
-            className="text-lg font-semibold text-foreground"
-          >
-            Members
-          </h2>
-          <button
-            type="button"
-            className="rounded-md bg-secondary px-3 py-1.5 text-sm font-medium text-secondary-foreground hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-          >
-            Add Member
-          </button>
-        </div>
+      {/* Members */}
+      <section aria-labelledby="members-heading">
+        <h2 id="members-heading" className="text-lg font-semibold text-foreground mb-4">
+          Members
+        </h2>
 
-        {project.members.length === 0 ? (
-          <p className="mt-4 text-sm text-muted-foreground">No members yet.</p>
+        {/* Add member form — admins only */}
+        {isProjectAdmin && (
+          <form onSubmit={handleAddMember} className="mb-4 flex gap-2 items-start flex-wrap">
+            <div className="flex flex-col gap-1">
+              <input
+                type="email"
+                value={addEmail}
+                onChange={(e) => setAddEmail(e.target.value)}
+                placeholder="Email address"
+                required
+                className="rounded border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
+            <select
+              value={addRole}
+              onChange={(e) => setAddRole(e.target.value as ProjectRole)}
+              className="rounded border border-input bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              {(Object.keys(ROLE_LABELS) as ProjectRole[]).map((r) => (
+                <option key={r} value={r}>{ROLE_LABELS[r]}</option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              disabled={addLoading}
+              className="rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {addLoading ? "Adding..." : "Add Member"}
+            </button>
+            {addError && (
+              <p className="w-full text-xs text-destructive mt-1">{addError}</p>
+            )}
+          </form>
+        )}
+
+        {/* Members table */}
+        {members.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No members yet.</p>
         ) : (
-          <ul className="mt-4 divide-y divide-border rounded-md border border-border">
-            {project.members.map((member) => (
-              <li
-                key={member.id}
-                className="flex items-center justify-between px-4 py-3"
-              >
-                <div>
-                  <p className="text-sm font-medium text-foreground">
-                    {member.user.name}
-                  </p>
-                  <p className="text-sm text-muted-foreground">{member.user.email}</p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium text-secondary-foreground">
-                    {member.role}
-                  </span>
-                  {member.isReviewer && (
-                    <span className="rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700">
-                      Reviewer
-                    </span>
+          <div className="rounded-md border border-border overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium text-muted-foreground">Name</th>
+                  <th className="px-4 py-2 text-left font-medium text-muted-foreground">Email</th>
+                  <th className="px-4 py-2 text-left font-medium text-muted-foreground">Role</th>
+                  {isProjectAdmin && (
+                    <th className="px-4 py-2 text-right font-medium text-muted-foreground">Actions</th>
                   )}
-                </div>
-              </li>
-            ))}
-          </ul>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {members.map((member) => (
+                  <tr key={member.id} className="bg-background hover:bg-muted/40">
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      {member.user.name ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{member.user.email}</td>
+                    <td className="px-4 py-3">
+                      {isProjectAdmin ? (
+                        <select
+                          value={member.role}
+                          disabled={updatingUserId === member.userId}
+                          onChange={(e) => handleRoleChange(member.userId, e.target.value as ProjectRole)}
+                          className="rounded border border-input bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                        >
+                          {(Object.keys(ROLE_LABELS) as ProjectRole[]).map((r) => (
+                            <option key={r} value={r}>{ROLE_LABELS[r]}</option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${ROLE_COLORS[member.role]}`}>
+                          {ROLE_LABELS[member.role]}
+                        </span>
+                      )}
+                    </td>
+                    {isProjectAdmin && (
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          onClick={() => handleRemove(member.userId)}
+                          disabled={removingUserId === member.userId}
+                          className="text-xs text-destructive hover:underline disabled:opacity-50"
+                        >
+                          {removingUserId === member.userId ? "Removing..." : "Remove"}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </section>
     </main>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -128,7 +128,7 @@ export default function SettingsPage() {
     return (
       <div className="mx-auto max-w-2xl px-4 py-8">
         <h1 className="mb-6 text-2xl font-bold">LLM Settings</h1>
-        <p className="text-gray-500">Loading...</p>
+        <p className="text-muted-foreground">Loading...</p>
       </div>
     );
   }
@@ -136,12 +136,12 @@ export default function SettingsPage() {
   return (
     <div className="mx-auto max-w-2xl px-4 py-8">
       <h1 className="mb-2 text-2xl font-bold">LLM Settings</h1>
-      <p className="mb-6 text-sm text-gray-500">
+      <p className="mb-6 text-sm text-muted-foreground">
         Configure your own LLM provider and API key. If not set, the global
         defaults will be used.
       </p>
 
-      <div className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="space-y-6 rounded-lg border border-border bg-card p-6 shadow-sm">
         {/* Provider */}
         <div className="space-y-2">
           <Label htmlFor="provider">Provider</Label>
@@ -166,7 +166,7 @@ export default function SettingsPage() {
             onChange={(e) => setModel(e.target.value)}
             placeholder={PROVIDER_DEFAULTS[provider]}
           />
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-muted-foreground">
             Leave blank to use the default for the selected provider
           </p>
         </div>

--- a/src/lib/prd/build-create-prompt.ts
+++ b/src/lib/prd/build-create-prompt.ts
@@ -2,8 +2,11 @@
  * Build the agent prompt for initial PRD creation.
  * Shared between the SSE generate endpoint and the background generator.
  */
-export function buildCreatePrompt(description: string): string {
-  return [
+export function buildCreatePrompt(
+  description: string,
+  context?: { userId?: string; projectId?: string },
+): string {
+  const lines = [
     `Create a comprehensive PRD for the following product:`,
     ``,
     description,
@@ -11,5 +14,14 @@ export function buildCreatePrompt(description: string): string {
     `Output the complete PRD as well-structured Markdown. Include sections for:`,
     `Summary, Problem Statement, User Analysis, Goals/Non-Goals,`,
     `Functional Requirements, Non-Functional Requirements, and Success Metrics.`,
-  ].join("\n");
+  ];
+
+  if (context?.userId || context?.projectId) {
+    lines.push(``);
+    lines.push(`## Session Context`);
+    if (context.userId) lines.push(`userId: ${context.userId}`);
+    if (context.projectId) lines.push(`projectId: ${context.projectId}`);
+  }
+
+  return lines.join("\n");
 }

--- a/src/services/__tests__/status-workflow-service.test.ts
+++ b/src/services/__tests__/status-workflow-service.test.ts
@@ -14,6 +14,7 @@ const mockPrdFindUnique = jest.fn();
 const mockPrdUpdate = jest.fn();
 const mockUserFindUnique = jest.fn();
 const mockPrdCoAuthorFindFirst = jest.fn();
+const mockProjectMemberFindUnique = jest.fn();
 const mockProjectMemberFindMany = jest.fn();
 const mockNotificationCreateMany = jest.fn();
 const mockCommentCount = jest.fn();
@@ -32,6 +33,7 @@ jest.mock("@/lib/prisma", () => ({
       findFirst: (...args: unknown[]) => mockPrdCoAuthorFindFirst(...args),
     },
     projectMember: {
+      findUnique: (...args: unknown[]) => mockProjectMemberFindUnique(...args),
       findMany: (...args: unknown[]) => mockProjectMemberFindMany(...args),
     },
     notification: {
@@ -82,6 +84,11 @@ const MOCK_PRD_APPROVED = {
   status: "APPROVED" as PrdStatus,
 };
 
+// Helper: membership with a given role
+function membership(role: string) {
+  return { id: "pm_1", projectId: "proj_001", userId: "user_1", role };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -93,13 +100,16 @@ describe("StatusWorkflowService", () => {
     jest.clearAllMocks();
     service = new StatusWorkflowService();
 
-    // Default: user exists as author
+    // Default: user exists as author (non-admin system role)
     mockUserFindUnique.mockResolvedValue({
       id: "user_author",
       name: "Author",
       email: "author@example.com",
       role: "AUTHOR",
     });
+
+    // Default: author has SUBMITTER project role
+    mockProjectMemberFindUnique.mockResolvedValue(membership("SUBMITTER"));
 
     // Default: no co-author relationship
     mockPrdCoAuthorFindFirst.mockResolvedValue(null);
@@ -202,9 +212,11 @@ describe("StatusWorkflowService", () => {
   // -----------------------------------------------------------------------
 
   describe("transition", () => {
-    it("should transition DRAFT -> IN_REVIEW for the author", async () => {
+    it("should transition DRAFT -> IN_REVIEW for the author (who is the PRD author)", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_DRAFT);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_DRAFT, status: "IN_REVIEW" });
+      // author is the PRD author — no project membership needed
+      mockProjectMemberFindUnique.mockResolvedValue(null);
 
       await service.transition("prd_001", "user_author", "IN_REVIEW");
 
@@ -222,6 +234,22 @@ describe("StatusWorkflowService", () => {
       );
     });
 
+    it("should transition DRAFT -> IN_REVIEW for a project SUBMITTER", async () => {
+      mockPrdFindUnique.mockResolvedValue(MOCK_PRD_DRAFT);
+      mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_DRAFT, status: "IN_REVIEW" });
+      mockUserFindUnique.mockResolvedValue({
+        id: "user_submitter",
+        name: "Submitter",
+        email: "submitter@example.com",
+        role: "AUTHOR",
+      });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("SUBMITTER"));
+
+      await service.transition("prd_001", "user_submitter", "IN_REVIEW");
+
+      expect(mockPrdUpdate).toHaveBeenCalled();
+    });
+
     it("should transition DRAFT -> IN_REVIEW for a co-author", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_DRAFT);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_DRAFT, status: "IN_REVIEW" });
@@ -231,6 +259,8 @@ describe("StatusWorkflowService", () => {
         email: "coauthor@example.com",
         role: "AUTHOR",
       });
+      // Not submitter/admin project role
+      mockProjectMemberFindUnique.mockResolvedValue(membership("MEMBER"));
       mockPrdCoAuthorFindFirst.mockResolvedValue({
         id: "ca_1",
         prdId: "prd_001",
@@ -261,30 +291,32 @@ describe("StatusWorkflowService", () => {
     it("should require comment when rejecting (IN_REVIEW -> DRAFT)", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockUserFindUnique.mockResolvedValue({
-        id: "user_reviewer",
-        name: "Reviewer",
-        email: "reviewer@example.com",
-        role: "REVIEWER",
+        id: "user_approver",
+        name: "Approver",
+        email: "approver@example.com",
+        role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("APPROVER"));
 
       await expect(
-        service.transition("prd_001", "user_reviewer", "DRAFT"),
+        service.transition("prd_001", "user_approver", "DRAFT"),
       ).rejects.toThrow("Comment is required when rejecting");
     });
 
-    it("should allow rejection with comment", async () => {
+    it("should allow rejection with comment by project APPROVER", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_IN_REVIEW, status: "DRAFT" });
       mockUserFindUnique.mockResolvedValue({
-        id: "user_reviewer",
-        name: "Reviewer",
-        email: "reviewer@example.com",
-        role: "REVIEWER",
+        id: "user_approver",
+        name: "Approver",
+        email: "approver@example.com",
+        role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("APPROVER"));
 
       await service.transition(
         "prd_001",
-        "user_reviewer",
+        "user_approver",
         "DRAFT",
         "Needs revision on section 3",
       );
@@ -295,7 +327,7 @@ describe("StatusWorkflowService", () => {
       });
       expect(mockLogTransition).toHaveBeenCalledWith(
         "prd_001",
-        "user_reviewer",
+        "user_approver",
         "STATUS_CHANGE",
         "IN_REVIEW",
         "DRAFT",
@@ -307,7 +339,7 @@ describe("StatusWorkflowService", () => {
     // Authorization checks
     // -------------------------------------------------------------------
 
-    it("should reject non-author/non-co-author submitting for review", async () => {
+    it("should reject member with MEMBER role submitting for review", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_DRAFT);
       mockUserFindUnique.mockResolvedValue({
         id: "user_random",
@@ -315,14 +347,15 @@ describe("StatusWorkflowService", () => {
         email: "random@example.com",
         role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("MEMBER"));
       mockPrdCoAuthorFindFirst.mockResolvedValue(null);
 
       await expect(
         service.transition("prd_001", "user_random", "IN_REVIEW"),
-      ).rejects.toThrow("Only the author or co-authors can submit for review");
+      ).rejects.toThrow("Only the author, co-authors, or project submitters can submit for review");
     });
 
-    it("should allow admin to perform any valid transition", async () => {
+    it("should allow system ADMIN to perform any valid transition", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_DRAFT);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_DRAFT, status: "IN_REVIEW" });
       mockUserFindUnique.mockResolvedValue({
@@ -331,13 +364,15 @@ describe("StatusWorkflowService", () => {
         email: "admin@example.com",
         role: "ADMIN",
       });
+      // System admin: projectMember.findUnique is not called
+      mockProjectMemberFindUnique.mockResolvedValue(null);
 
       await service.transition("prd_001", "user_admin", "IN_REVIEW");
 
       expect(mockPrdUpdate).toHaveBeenCalled();
     });
 
-    it("should reject non-reviewer/non-admin approving", async () => {
+    it("should reject non-approver approving (only MEMBER project role)", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockUserFindUnique.mockResolvedValue({
         id: "user_author",
@@ -345,24 +380,43 @@ describe("StatusWorkflowService", () => {
         email: "author@example.com",
         role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("MEMBER"));
 
       await expect(
         service.transition("prd_001", "user_author", "APPROVED"),
-      ).rejects.toThrow("Only reviewers or admins can approve");
+      ).rejects.toThrow("Only project approvers or admins can approve");
     });
 
-    it("should allow reviewer to approve", async () => {
+    it("should allow project APPROVER to approve", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_IN_REVIEW, status: "APPROVED" });
       mockUserFindUnique.mockResolvedValue({
-        id: "user_reviewer",
-        name: "Reviewer",
-        email: "reviewer@example.com",
-        role: "REVIEWER",
+        id: "user_approver",
+        name: "Approver",
+        email: "approver@example.com",
+        role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("APPROVER"));
       mockCommentCount.mockResolvedValue(0);
 
-      await service.transition("prd_001", "user_reviewer", "APPROVED");
+      await service.transition("prd_001", "user_approver", "APPROVED");
+
+      expect(mockPrdUpdate).toHaveBeenCalled();
+    });
+
+    it("should allow project ADMIN to approve", async () => {
+      mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
+      mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_IN_REVIEW, status: "APPROVED" });
+      mockUserFindUnique.mockResolvedValue({
+        id: "user_proj_admin",
+        name: "Project Admin",
+        email: "padmin@example.com",
+        role: "AUTHOR",
+      });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("ADMIN"));
+      mockCommentCount.mockResolvedValue(0);
+
+      await service.transition("prd_001", "user_proj_admin", "APPROVED");
 
       expect(mockPrdUpdate).toHaveBeenCalled();
     });
@@ -371,12 +425,13 @@ describe("StatusWorkflowService", () => {
     // TASK-028: Reviewer auto-assignment
     // -------------------------------------------------------------------
 
-    it("should notify reviewers when transitioning to IN_REVIEW", async () => {
+    it("should notify REVIEWER/APPROVER/ADMIN members when transitioning to IN_REVIEW", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_DRAFT);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_DRAFT, status: "IN_REVIEW" });
+      mockProjectMemberFindUnique.mockResolvedValue(null); // author is PRD author
       mockProjectMemberFindMany.mockResolvedValue([
-        { userId: "user_rev1", isReviewer: true },
-        { userId: "user_rev2", isReviewer: true },
+        { userId: "user_rev1", role: "REVIEWER" },
+        { userId: "user_rev2", role: "APPROVER" },
       ]);
       mockNotificationCreateMany.mockResolvedValue({ count: 2 });
 
@@ -385,7 +440,7 @@ describe("StatusWorkflowService", () => {
       expect(mockProjectMemberFindMany).toHaveBeenCalledWith({
         where: {
           projectId: "proj_001",
-          isReviewer: true,
+          role: { in: ["REVIEWER", "APPROVER", "ADMIN"] },
         },
       });
       expect(mockNotificationCreateMany).toHaveBeenCalledWith({
@@ -409,6 +464,7 @@ describe("StatusWorkflowService", () => {
     it("should not create notifications when no reviewers exist", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_DRAFT);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_DRAFT, status: "IN_REVIEW" });
+      mockProjectMemberFindUnique.mockResolvedValue(null); // PRD author
       mockProjectMemberFindMany.mockResolvedValue([]);
 
       await service.transition("prd_001", "user_author", "IN_REVIEW");
@@ -423,11 +479,12 @@ describe("StatusWorkflowService", () => {
     it("should block approval when unresolved comments exist and setting is enabled", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockUserFindUnique.mockResolvedValue({
-        id: "user_reviewer",
-        name: "Reviewer",
-        email: "reviewer@example.com",
-        role: "REVIEWER",
+        id: "user_approver",
+        name: "Approver",
+        email: "approver@example.com",
+        role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("APPROVER"));
       mockGlobalSettingsFindUnique.mockResolvedValue({
         id: "global",
         blockApprovalOnUnresolvedComments: true,
@@ -435,7 +492,7 @@ describe("StatusWorkflowService", () => {
       mockCommentCount.mockResolvedValue(3);
 
       await expect(
-        service.transition("prd_001", "user_reviewer", "APPROVED"),
+        service.transition("prd_001", "user_approver", "APPROVED"),
       ).rejects.toThrow("Cannot approve: 3 unresolved comment(s) remain");
     });
 
@@ -443,18 +500,19 @@ describe("StatusWorkflowService", () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_IN_REVIEW, status: "APPROVED" });
       mockUserFindUnique.mockResolvedValue({
-        id: "user_reviewer",
-        name: "Reviewer",
-        email: "reviewer@example.com",
-        role: "REVIEWER",
+        id: "user_approver",
+        name: "Approver",
+        email: "approver@example.com",
+        role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("APPROVER"));
       mockGlobalSettingsFindUnique.mockResolvedValue({
         id: "global",
         blockApprovalOnUnresolvedComments: false,
       });
       mockCommentCount.mockResolvedValue(3);
 
-      await service.transition("prd_001", "user_reviewer", "APPROVED");
+      await service.transition("prd_001", "user_approver", "APPROVED");
 
       expect(mockPrdUpdate).toHaveBeenCalled();
     });
@@ -463,14 +521,15 @@ describe("StatusWorkflowService", () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_IN_REVIEW, status: "APPROVED" });
       mockUserFindUnique.mockResolvedValue({
-        id: "user_reviewer",
-        name: "Reviewer",
-        email: "reviewer@example.com",
-        role: "REVIEWER",
+        id: "user_approver",
+        name: "Approver",
+        email: "approver@example.com",
+        role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("APPROVER"));
       mockCommentCount.mockResolvedValue(0);
 
-      await service.transition("prd_001", "user_reviewer", "APPROVED");
+      await service.transition("prd_001", "user_approver", "APPROVED");
 
       expect(mockPrdUpdate).toHaveBeenCalled();
     });
@@ -479,15 +538,16 @@ describe("StatusWorkflowService", () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_IN_REVIEW);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_IN_REVIEW, status: "APPROVED" });
       mockUserFindUnique.mockResolvedValue({
-        id: "user_reviewer",
-        name: "Reviewer",
-        email: "reviewer@example.com",
-        role: "REVIEWER",
+        id: "user_approver",
+        name: "Approver",
+        email: "approver@example.com",
+        role: "AUTHOR",
       });
+      mockProjectMemberFindUnique.mockResolvedValue(membership("APPROVER"));
       mockGlobalSettingsFindUnique.mockResolvedValue(null);
       mockCommentCount.mockResolvedValue(5);
 
-      await service.transition("prd_001", "user_reviewer", "APPROVED");
+      await service.transition("prd_001", "user_approver", "APPROVED");
 
       expect(mockPrdUpdate).toHaveBeenCalled();
     });
@@ -499,6 +559,7 @@ describe("StatusWorkflowService", () => {
     it("should transition APPROVED -> SUBMITTED for the author", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_APPROVED);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_APPROVED, status: "SUBMITTED" });
+      mockProjectMemberFindUnique.mockResolvedValue(null); // PRD author
 
       await service.transition("prd_001", "user_author", "SUBMITTED");
 
@@ -515,6 +576,7 @@ describe("StatusWorkflowService", () => {
     it("should allow re-opening an approved PRD (APPROVED -> DRAFT)", async () => {
       mockPrdFindUnique.mockResolvedValue(MOCK_PRD_APPROVED);
       mockPrdUpdate.mockResolvedValue({ ...MOCK_PRD_APPROVED, status: "DRAFT" });
+      mockProjectMemberFindUnique.mockResolvedValue(null); // PRD author
 
       await service.transition("prd_001", "user_author", "DRAFT");
 

--- a/src/services/agent/prd-generator.ts
+++ b/src/services/agent/prd-generator.ts
@@ -104,7 +104,10 @@ async function runGeneration(opts: TriggerPrdGenerationOptions): Promise<void> {
     // -----------------------------------------------------------------------
     // 3. Send the description as the initial prompt
     // -----------------------------------------------------------------------
-    const prompt = buildCreatePrompt(opts.description);
+    const prompt = buildCreatePrompt(opts.description, {
+      userId: opts.userId,
+      projectId: opts.projectId,
+    });
 
     // Collect the full response text
     let generatedContent = "";

--- a/src/services/status-workflow-service.ts
+++ b/src/services/status-workflow-service.ts
@@ -3,7 +3,11 @@
  *
  * Implements a state machine for PRD status transitions with:
  * - Transition validation (only allowed paths)
- * - Authorization checks (author/co-author for submit, reviewer/admin for approve)
+ * - Authorization checks using project-level roles (ProjectMember.role)
+ *   SUBMITTER → can submit DRAFT→IN_REVIEW
+ *   APPROVER  → can approve/reject (IN_REVIEW→APPROVED or IN_REVIEW→DRAFT)
+ *   project ADMIN → can do anything a project admin needs
+ *   System ADMIN  → overrides all checks
  * - Reviewer auto-assignment notifications on IN_REVIEW (TASK-028)
  * - Unresolved comment blocking on APPROVED (TASK-031)
  * - Audit trail logging on every transition (TASK-034)
@@ -97,36 +101,44 @@ export class StatusWorkflowService {
       );
     }
 
-    // 3. Fetch the acting user
+    // 3. Fetch the acting user and their project membership
     const user = await prisma.user.findUnique({ where: { id: userId } });
-    const userRole = user?.role;
-    const isAdmin = userRole === "ADMIN";
+    const systemRole = user?.role;
+    const isSystemAdmin = systemRole === "ADMIN";
 
-    // 4. Authorization checks
-    await this.checkAuthorization(prd, userId, userRole, isAdmin, fromStatus, toStatus);
+    // 4. Fetch project membership for project-level role checks
+    const membership = isSystemAdmin
+      ? null
+      : await prisma.projectMember.findUnique({
+          where: { projectId_userId: { projectId: prd.projectId, userId } },
+        });
+    const projectRole = membership?.role ?? null;
 
-    // 5. Rejection requires a comment
+    // 5. Authorization checks
+    await this.checkAuthorization(prd, userId, isSystemAdmin, projectRole, fromStatus, toStatus);
+
+    // 6. Rejection requires a comment
     if (fromStatus === "IN_REVIEW" && toStatus === "DRAFT" && !comment) {
       throw new ValidationError("Comment is required when rejecting a PRD");
     }
 
-    // 6. TASK-031: Check unresolved comments when approving
+    // 7. TASK-031: Check unresolved comments when approving
     if (toStatus === "APPROVED") {
       await this.checkUnresolvedComments(prdId);
     }
 
-    // 7. Update the status
+    // 8. Update the status
     await prisma.prd.update({
       where: { id: prdId },
       data: { status: toStatus },
     });
 
-    // 8. TASK-028: Notify reviewers when entering IN_REVIEW
+    // 9. TASK-028: Notify reviewers when entering IN_REVIEW
     if (toStatus === "IN_REVIEW") {
       await this.notifyReviewers(prd.projectId, prdId, prd.title);
     }
 
-    // 9. TASK-034: Log audit entry
+    // 10. TASK-034: Log audit entry
     await this.auditService.logTransition(
       prdId,
       userId,
@@ -143,61 +155,63 @@ export class StatusWorkflowService {
 
   /**
    * Verify the user has permission to perform the requested transition.
+   *
+   * Authorization matrix:
+   *   DRAFT → IN_REVIEW:   PRD author, co-author, project SUBMITTER/ADMIN, system ADMIN
+   *   IN_REVIEW → APPROVED: project APPROVER/ADMIN, system ADMIN
+   *   IN_REVIEW → DRAFT:   project APPROVER/ADMIN, system ADMIN (rejection)
+   *   APPROVED → SUBMITTED: PRD author, co-author, project ADMIN, system ADMIN
+   *   APPROVED → DRAFT:    PRD author, co-author, project ADMIN, system ADMIN
+   *   SUBMITTED → DRAFT:   PRD author, co-author, project ADMIN, system ADMIN
    */
   private async checkAuthorization(
     prd: { id: string; authorId: string; projectId: string },
     userId: string,
-    userRole: string | undefined,
-    isAdmin: boolean,
+    isSystemAdmin: boolean,
+    projectRole: string | null,
     fromStatus: PrdStatus,
     toStatus: PrdStatus,
   ): Promise<void> {
-    // Admins can always perform valid transitions
-    if (isAdmin) return;
+    // System admins can always perform valid transitions
+    if (isSystemAdmin) return;
 
-    // DRAFT -> IN_REVIEW: only author or co-author
+    // DRAFT -> IN_REVIEW: author, co-author, project SUBMITTER or project ADMIN
     if (fromStatus === "DRAFT" && toStatus === "IN_REVIEW") {
+      if (projectRole === "SUBMITTER" || projectRole === "ADMIN") return;
       const isAuthor = prd.authorId === userId;
-      if (!isAuthor) {
-        const coAuthor = await prisma.prdCoAuthor.findFirst({
-          where: { prdId: prd.id, userId },
-        });
-        if (!coAuthor) {
-          throw new ForbiddenError(
-            "Only the author or co-authors can submit for review",
-          );
-        }
-      }
-      return;
+      if (isAuthor) return;
+      const coAuthor = await prisma.prdCoAuthor.findFirst({
+        where: { prdId: prd.id, userId },
+      });
+      if (coAuthor) return;
+      throw new ForbiddenError(
+        "Only the author, co-authors, or project submitters can submit for review",
+      );
     }
 
-    // IN_REVIEW -> APPROVED: only reviewer or admin
+    // IN_REVIEW -> APPROVED: project APPROVER or project ADMIN
     if (fromStatus === "IN_REVIEW" && toStatus === "APPROVED") {
-      if (userRole !== "REVIEWER") {
-        throw new ForbiddenError("Only reviewers or admins can approve");
-      }
-      return;
+      if (projectRole === "APPROVER" || projectRole === "ADMIN") return;
+      throw new ForbiddenError("Only project approvers or admins can approve");
     }
 
-    // IN_REVIEW -> DRAFT (rejection): only reviewer or admin
+    // IN_REVIEW -> DRAFT (rejection): project APPROVER or project ADMIN
     if (fromStatus === "IN_REVIEW" && toStatus === "DRAFT") {
-      if (userRole !== "REVIEWER") {
-        throw new ForbiddenError("Only reviewers or admins can reject");
-      }
-      return;
+      if (projectRole === "APPROVER" || projectRole === "ADMIN") return;
+      throw new ForbiddenError("Only project approvers or admins can reject");
     }
 
-    // APPROVED -> SUBMITTED or APPROVED -> DRAFT or SUBMITTED -> DRAFT: author/co-author/admin
+    // APPROVED -> SUBMITTED or APPROVED -> DRAFT or SUBMITTED -> DRAFT:
+    // author, co-author, or project ADMIN
     if (fromStatus === "APPROVED" || fromStatus === "SUBMITTED") {
+      if (projectRole === "ADMIN") return;
       const isAuthor = prd.authorId === userId;
-      if (!isAuthor) {
-        const coAuthor = await prisma.prdCoAuthor.findFirst({
-          where: { prdId: prd.id, userId },
-        });
-        if (!coAuthor) {
-          throw new ForbiddenError("Insufficient permissions for this transition");
-        }
-      }
+      if (isAuthor) return;
+      const coAuthor = await prisma.prdCoAuthor.findFirst({
+        where: { prdId: prd.id, userId },
+      });
+      if (coAuthor) return;
+      throw new ForbiddenError("Insufficient permissions for this transition");
     }
   }
 
@@ -235,7 +249,7 @@ export class StatusWorkflowService {
     const reviewers = await prisma.projectMember.findMany({
       where: {
         projectId,
-        isReviewer: true,
+        role: { in: ["REVIEWER", "APPROVER", "ADMIN"] },
       },
     });
 

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -3,6 +3,7 @@ export interface CommentData {
   authorId: string;
   authorName: string;
   body: string;
+  parentId?: string | null;
   resolved: boolean;
   resolvedBy?: string;
   createdAt: string;


### PR DESCRIPTION
## Summary

- Added `ProjectRole` enum (MEMBER, REVIEWER, SUBMITTER, APPROVER, ADMIN) replacing the old boolean `isReviewer` field on `ProjectMember`
- Project creators are automatically assigned the ADMIN role; all member management endpoints now use role-based authorization
- Members tab UI updated to allow admins to add/remove members and change roles, with read-only view for non-admins

## Changes

### Database
- `prisma/schema.prisma` - Added `ProjectRole` enum, replaced `isReviewer: Boolean` with `role: ProjectRole` on `ProjectMember`
- `prisma/migrations/20260305000000_add_project_role_enum/migration.sql` - Migration to add the enum and update the column

### API Routes
- `src/app/api/projects/route.ts` - Project creator now receives ADMIN role; fixed member creation logic
- `src/app/api/projects/[id]/members/route.ts` - POST accepts `email` + `role`; GET lists members; guarded by project/system ADMIN check
- `src/app/api/projects/[id]/members/[userId]/route.ts` - Added PATCH for role updates, DELETE for member removal

### Services
- `src/services/status-workflow-service.ts` - PRD workflow authorization now uses project-level roles instead of the old boolean

### UI
- `src/app/projects/[id]/page.tsx` - Members tab with add/remove/role-change for ADMINs, read-only for others

### Types & Bug Fixes
- `src/types/comments.ts` - Added `parentId` field
- `src/app/api/prds/[id]/comments/route.ts` - Bug fixes in `toCommentData` serializer

### Tests
- Updated `src/services/__tests__/status-workflow-service.test.ts`, `src/app/api/projects/[id]/__tests__/route.test.ts`, `src/app/api/projects/[id]/members/__tests__/route.test.ts`, `src/app/api/prds/[id]/comments/__tests__/route.test.ts`, and `src/__tests__/e2e-flow.test.ts` to reflect new role model

## Test plan

- [ ] Run `devbox run test` and confirm all tests pass
- [ ] Create a new project and verify the creator is assigned ADMIN role
- [ ] As ADMIN, add a member with each role (MEMBER, REVIEWER, SUBMITTER, APPROVER) via the Members tab
- [ ] As ADMIN, update a member's role and verify the change persists
- [ ] As ADMIN, remove a member and verify they no longer appear
- [ ] As a non-ADMIN member, verify the Members tab is read-only
- [ ] Submit a PRD and verify the workflow authorization uses project-level roles correctly
- [ ] Run `prisma migrate deploy` against a staging DB to confirm the migration applies cleanly

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>